### PR TITLE
22106: Fixed a bug that caused "Buffer/" imports to break applications (2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,6 @@
       "name": "@howso/howso-visuals",
       "version": "0.0.0",
       "license": "ISC",
-      "dependencies": {
-        "classnames": "^2.5.1",
-        "d3": "^7.9.0",
-        "d3-array": "^1.2.4",
-        "tinycolor2": "^1.6.0"
-      },
       "devDependencies": {
         "@chromatic-com/storybook": "^2.0.2",
         "@fontsource/inter": "^5.0.5",
@@ -73,10 +67,12 @@
         "@rollup/rollup-linux-x64-gnu": "^4.9.6"
       },
       "peerDependencies": {
-        "plotly.js-strict-dist": "^2.35.0",
+        "classnames": "^2.5.1",
+        "d3": "^7.9.0",
+        "d3-array": "^1.2.4",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "react-plotly.js": "^2.6.0"
+        "tinycolor2": "^1.6.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7795,7 +7791,8 @@
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "peer": true
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -8583,6 +8580,7 @@
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
       "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "peer": true,
       "dependencies": {
         "d3-array": "3",
         "d3-axis": "3",
@@ -8628,6 +8626,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
       "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8636,6 +8635,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
       "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -8651,6 +8651,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
       "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "peer": true,
       "dependencies": {
         "d3-path": "1 - 3"
       },
@@ -8676,6 +8677,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
       "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.0"
       },
@@ -8687,6 +8689,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
       "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "peer": true,
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -8698,6 +8701,7 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
       "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "peer": true,
       "dependencies": {
         "delaunator": "5"
       },
@@ -8714,6 +8718,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
       "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -8726,6 +8731,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
       "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "peer": true,
       "dependencies": {
         "commander": "7",
         "iconv-lite": "0.6",
@@ -8750,6 +8756,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -8758,6 +8765,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -8769,6 +8777,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8777,6 +8786,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
       "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "peer": true,
       "dependencies": {
         "d3-dsv": "1 - 3"
       },
@@ -8861,6 +8871,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
       "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8875,6 +8886,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
       "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8883,6 +8895,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "peer": true,
       "dependencies": {
         "d3-array": "2.10.0 - 3",
         "d3-format": "1 - 3",
@@ -8898,6 +8911,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
       "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
@@ -8910,6 +8924,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
       "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "peer": true,
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -8921,6 +8936,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
       "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "peer": true,
       "dependencies": {
         "d3-array": "2 - 3"
       },
@@ -8932,6 +8948,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8967,6 +8984,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
       "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -8985,6 +9003,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
       "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -9000,6 +9019,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
       "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "peer": true,
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -9011,6 +9031,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
       "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9019,6 +9040,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
       "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-quadtree": "1 - 3",
@@ -9032,6 +9054,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9040,6 +9063,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
       "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "peer": true,
       "dependencies": {
         "d3-array": "2.5.0 - 3"
       },
@@ -9051,6 +9075,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
       "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9059,6 +9084,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9067,6 +9093,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
       "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9075,6 +9102,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
       "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "peer": true,
       "dependencies": {
         "d3-path": "^3.1.0"
       },
@@ -9086,6 +9114,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
       "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "peer": true,
       "dependencies": {
         "d3-array": "2 - 3"
       },
@@ -9097,6 +9126,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
       "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "peer": true,
       "dependencies": {
         "d3-time": "1 - 3"
       },
@@ -9108,6 +9138,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9294,6 +9325,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
       "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "peer": true,
       "dependencies": {
         "robust-predicates": "^3.0.2"
       }
@@ -12149,6 +12181,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -22395,7 +22428,8 @@
     "node_modules/robust-predicates": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "peer": true
     },
     "node_modules/rollup": {
       "version": "4.22.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
       "devDependencies": {
         "@chromatic-com/storybook": "^2.0.2",
         "@fontsource/inter": "^5.0.5",
+        "@rollup/plugin-commonjs": "^28.0.1",
+        "@rollup/plugin-node-resolve": "^15.3.0",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^11.1.6",
         "@storybook/addon-a11y": "^8.3.2",
@@ -71,7 +73,7 @@
         "@rollup/rollup-linux-x64-gnu": "^4.9.6"
       },
       "peerDependencies": {
-        "plotly.js-strict-dist": "^2.29.1",
+        "plotly.js-strict-dist": "^2.35.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-plotly.js": "^2.6.0"
@@ -3928,6 +3930,88 @@
         "parse-rect": "^1.2.0",
         "pick-by-alias": "^1.2.0"
       }
+    },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.1.tgz",
+      "integrity": "sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+      "dev": true,
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.0.tgz",
+      "integrity": "sha512-9eO5McEICxMzJpDW9OnMYSv4Sta3hmt7VtBFz5zR9273suNOydOyq/FrGeGy+KsTRFm8w0SLVhzig2ILFT63Ag==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve/node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true
     },
     "node_modules/@rollup/plugin-terser": {
       "version": "0.4.4",
@@ -12348,6 +12432,12 @@
       "integrity": "sha512-mlcHZA84t1qLSuWkt2v0I2l61PYdyQDt4aG1mLIXF5FDMm4+haBCxCPYSr/uwqQNRk1MiTizn0ypEuRAOLRAew==",
       "dev": true
     },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -12428,6 +12518,15 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/is-regex": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "lib"
   ],
   "peerDependencies": {
+    "classnames": "^2.5.1",
     "d3": "^7.9.0",
     "d3-array": "^1.2.4",
-    "tinycolor2": "^1.6.0",
-    "classnames": "^2.5.1",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "tinycolor2": "^1.6.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.9.6"

--- a/package.json
+++ b/package.json
@@ -31,17 +31,13 @@
   "files": [
     "lib"
   ],
-  "dependencies": {
-    "classnames": "^2.5.1",
+  "peerDependencies": {
     "d3": "^7.9.0",
     "d3-array": "^1.2.4",
-    "tinycolor2": "^1.6.0"
-  },
-  "peerDependencies": {
-    "plotly.js-strict-dist": "^2.29.1",
+    "tinycolor2": "^1.6.0",
+    "classnames": "^2.5.1",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "react-plotly.js": "^2.6.0"
+    "react-dom": "^18.0.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.9.6"
@@ -49,6 +45,8 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^2.0.2",
     "@fontsource/inter": "^5.0.5",
+    "@rollup/plugin-commonjs": "^28.0.1",
+    "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
     "@storybook/addon-a11y": "^8.3.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,10 @@
-import terser from "@rollup/plugin-terser";
+import commonjs from '@rollup/plugin-commonjs';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
 import typescript from "@rollup/plugin-typescript";
 import autoprefixer from 'autoprefixer';
 import postcss from 'rollup-plugin-postcss';
 import pkg from "./package.json" with { type: "json" };
+
 
 /**
  * @type {import('rollup').RollupOptions}
@@ -15,6 +17,8 @@ export default {
       noEmitOnError: true,
       tsconfig: "./tsconfig.build.json",
     }),
+    nodeResolve(),
+    commonjs(),
     postcss({
       plugins: [autoprefixer()],
       sourceMap: true,
@@ -22,7 +26,7 @@ export default {
       minimize: true,
       modules: true,
     }),
-    terser(), // minifies generated bundles
+    // terser(), // minifies generated bundles
   ],
   external: [
     "react/jsx-runtime",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,6 @@ export default {
       minimize: true,
       modules: true,
     }),
-    // terser(), // minifies generated bundles
   ],
   external: [
     "react/jsx-runtime",

--- a/src/components/Anomalies/Anomalies.tsx
+++ b/src/components/Anomalies/Anomalies.tsx
@@ -1,6 +1,5 @@
 import type { Annotations, ColorScale, Data, Layout } from "plotly.js";
 import { CSSProperties, ReactNode, useMemo } from "react";
-import Plot from "react-plotly.js";
 import {
   Divergent1Colorway,
   getColorFromScale,
@@ -16,6 +15,11 @@ import {
 import { colorbarDefaults } from "../../plotly/colorbar";
 import { FormatCategoryTickTextParams } from "../../utils";
 import { BaseVisualProps, plotDefaults } from "../BaseVisual";
+// customizable method: use your own `Plotly` object as we're using a rebuild strict distribution
+import createPlotlyComponent from "react-plotly.js/factory";
+// @ts-expect-error
+import Plotly from "plotly.js-strict-dist";
+const Plot = createPlotlyComponent(Plotly);
 
 export type AnomaliesProps = BaseVisualProps &
   ScreenSizeHookProps & {

--- a/src/components/DesirabilityGauge/DesirabilityGauge.tsx
+++ b/src/components/DesirabilityGauge/DesirabilityGauge.tsx
@@ -1,8 +1,12 @@
-import { useMemo, type CSSProperties, ReactNode } from "react";
-import Plot from "react-plotly.js";
+import { ReactNode, useMemo, type CSSProperties } from "react";
 import { getColorScheme } from "../../colors";
 import { useLayoutDefaults, useSemanticColors } from "../../hooks";
 import { BaseVisualProps, plotDefaults } from "../BaseVisual";
+// customizable method: use your own `Plotly` object as we're using a rebuild strict distribution
+import createPlotlyComponent from "react-plotly.js/factory";
+// @ts-expect-error
+import Plotly from "plotly.js-strict-dist";
+const Plot = createPlotlyComponent(Plotly);
 
 export interface DesirabilityGaugeProps extends BaseVisualProps {
   value: number;

--- a/src/components/FeatureContributions/FeatureContributionsVerticalBarChart/FeatureContributionsVerticalBarChart.tsx
+++ b/src/components/FeatureContributions/FeatureContributionsVerticalBarChart/FeatureContributionsVerticalBarChart.tsx
@@ -1,6 +1,5 @@
 import type { Config, Datum, Layout, PlotData } from "plotly.js";
 import { useMemo, type CSSProperties, type ReactNode } from "react";
-import Plot from "react-plotly.js";
 import { getColorScheme } from "../../../colors";
 import {
   useLayoutCategoryAxisDefaults,
@@ -12,6 +11,11 @@ import {
 import { FormatCategoryTickTextParams } from "../../../utils";
 import { plotDefaults } from "../../BaseVisual";
 import { FeatureContributionsBaseVisualProps } from "../FeatureContributions.types";
+// customizable method: use your own `Plotly` object as we're using a rebuild strict distribution
+import createPlotlyComponent from "react-plotly.js/factory";
+// @ts-expect-error
+import Plotly from "plotly.js-strict-dist";
+const Plot = createPlotlyComponent(Plotly);
 
 export type FeatureContributionsVerticalBarChartProps =
   FeatureContributionsBaseVisualProps &

--- a/src/components/FeatureCorrelations/FeatureCorrelations.tsx
+++ b/src/components/FeatureCorrelations/FeatureCorrelations.tsx
@@ -1,5 +1,6 @@
+import type { Annotations, ColorScale, Data, Datum, Layout } from "plotly.js";
 import { type CSSProperties, type ReactNode, useMemo } from "react";
-import Plot from "react-plotly.js";
+import { FormatCategoryTickTextParams } from "../..";
 import {
   Divergent1Colorway,
   getColorFromScale,
@@ -13,10 +14,13 @@ import {
   useLayoutCategoryAxisDefaults,
   useLayoutDefaults,
 } from "../../hooks";
-import { type BaseVisualProps, plotDefaults } from "../BaseVisual";
-import type { Annotations, ColorScale, Data, Datum, Layout } from "plotly.js";
-import { FormatCategoryTickTextParams } from "../..";
 import { colorbarDefaults } from "../../plotly/colorbar";
+import { type BaseVisualProps, plotDefaults } from "../BaseVisual";
+// customizable method: use your own `Plotly` object as we're using a rebuild strict distribution
+import createPlotlyComponent from "react-plotly.js/factory";
+// @ts-expect-error
+import Plotly from "plotly.js-strict-dist";
+const Plot = createPlotlyComponent(Plotly);
 
 export type FeatureCorrelationsProps = BaseVisualProps &
   ScreenSizeHookProps & {

--- a/src/components/InfluenceWeights/InfluenceWeights.tsx
+++ b/src/components/InfluenceWeights/InfluenceWeights.tsx
@@ -1,19 +1,23 @@
+import type { Data, Layout, ScatterData } from "plotly.js";
 import { type CSSProperties, type ReactNode, useMemo } from "react";
-import Plot from "react-plotly.js";
+import { FormatCategoryTickTextParams, parseNA, roundTo } from "../..";
 import { getColorScheme } from "../../colors";
 import {
-  type ScreenSizeHookProps,
-  useLayoutDefaults,
   getCaseLabel,
   getDataMeta,
-  UseLayoutCategoryAxisDefaultsParams,
+  type ScreenSizeHookProps,
   useLayoutCategoryAxisDefaults,
+  UseLayoutCategoryAxisDefaultsParams,
+  useLayoutDefaults,
   useSemanticColors,
 } from "../../hooks";
-import { type BaseVisualProps, plotDefaults } from "../BaseVisual";
-import type { Data, Layout, ScatterData } from "plotly.js";
-import { FormatCategoryTickTextParams, parseNA, roundTo } from "../..";
 import { Case, IdFeaturesProps } from "../../types";
+import { type BaseVisualProps, plotDefaults } from "../BaseVisual";
+// customizable method: use your own `Plotly` object as we're using a rebuild strict distribution
+import createPlotlyComponent from "react-plotly.js/factory";
+// @ts-expect-error
+import Plotly from "plotly.js-strict-dist";
+const Plot = createPlotlyComponent(Plotly);
 
 type GetInfluenceDataGroups = (
   data: Partial<ScatterData>

--- a/src/components/InfluentialCases/InfluentialCases.tsx
+++ b/src/components/InfluentialCases/InfluentialCases.tsx
@@ -1,7 +1,6 @@
 import { extent, range } from "d3-array";
 import type { Data, Layout, ScatterMarkerLine } from "plotly.js";
 import { CSSProperties, ReactNode, useMemo } from "react";
-import Plot from "react-plotly.js";
 import { ChartColors, NamedColor, getColorScheme } from "../../colors";
 import {
   getCaseLabel,
@@ -18,6 +17,11 @@ import {
   safeMin,
 } from "../../utils";
 import { BaseVisualProps, plotDefaults } from "../BaseVisual";
+// customizable method: use your own `Plotly` object as we're using a rebuild strict distribution
+import createPlotlyComponent from "react-plotly.js/factory";
+// @ts-expect-error
+import Plotly from "plotly.js-strict-dist";
+const Plot = createPlotlyComponent(Plotly);
 
 export type InfluentialCasesProps = BaseVisualProps &
   IdFeaturesProps & {

--- a/src/components/SimilarityConviction/SimilarityConviction.tsx
+++ b/src/components/SimilarityConviction/SimilarityConviction.tsx
@@ -1,6 +1,5 @@
 import type { Data, Layout } from "plotly.js";
 import { CSSProperties, ReactNode, useMemo } from "react";
-import Plot from "react-plotly.js";
 import { getColorScheme } from "../../colors";
 import {
   getCaseLabel,
@@ -10,6 +9,11 @@ import {
 import { IdFeaturesProps } from "../../types";
 import { parseNA } from "../../utils";
 import { BaseVisualProps, plotDefaults } from "../BaseVisual";
+// customizable method: use your own `Plotly` object as we're using a rebuild strict distribution
+import createPlotlyComponent from "react-plotly.js/factory";
+// @ts-expect-error
+import Plotly from "plotly.js-strict-dist";
+const Plot = createPlotlyComponent(Plotly);
 
 export type SimilarityConvictionCase = {
   similarity_conviction: number | null;


### PR DESCRIPTION
- Updated Plotly import pattern to use the Factor for bundled distribution.
- Removed plotly as a peer dependency by packing strict-dist it directly into the build
- Modified Rollup use node resolution and accept common js without minification